### PR TITLE
fix: insert scf event and context in NestJS tpl

### DIFF
--- a/packages/cloudbase-node-builder/asset/__launcher.js
+++ b/packages/cloudbase-node-builder/asset/__launcher.js
@@ -18,7 +18,7 @@ module.exports.main = async (event, context) => {
 
   // support for async load app
   if (entry && entry.tcbGetApp && typeof entry.tcbGetApp === 'function') {
-    app = await entry.tcbGetApp();
+    app = await entry.tcbGetApp(event, context);
   }
 
   return serverless(app, {


### PR DESCRIPTION
## Description

When I want to use event and context in my server app, it returns empty object. The smalleset demo as follows:

`WORK_DIR/src/main.ts`: 

```ts
import * as express from 'express';
import { NestFactory } from '@nestjs/core';
import {
    ExpressAdapter,
    NestExpressApplication
} from '@nestjs/platform-express'
import * as url from 'url';
import { AppModule } from './app.module';

const expressApp = express();
const adapter = new ExpressAdapter(expressApp);
const port = process.env.PORT || 9001;

export async function bootstrap(event?, context?) {
    console.log('>>> context and event', context, event)
    process.env.SCF_REQUEST_ID = context?.request_id || ''

    const app = await NestFactory.create<NestExpressApplication>(
        AppModule,
        adapter
    );
    await app.init();
    return expressApp;
}

bootstrap().then(() => {
        console.log(JSON.stringify({
            type: 'StartServer',
            logTime: Date.now(),
            content: `App listen on http://localhost:${port}`
        }));
    });
```

`WORK_DIR/app.js`: 

```js
/* eslint-disable */
const main = require('./dist/src/main')

exports.tcbGetApp = main.bootstrap
```

## Solution

Inject event and context object when invoke function `entry.tcbGetApp()`.

Fixs #

Changes in this pull request

- 
- 
-

@binggg
