### PR TITLE
feat(framework-plugin-next): 新增安装命令配置

### DIFF
--- a/packages/framework-plugin-next/src/index.ts
+++ b/packages/framework-plugin-next/src/index.ts
@@ -20,6 +20,7 @@ const DEFAULT_INPUTS = {
   name: 'next-ssr',
   path: '/next-ssr',
   buildCommand: 'npm run build',
+  installCommand:'npm install',
 };
 
 /**
@@ -50,6 +51,12 @@ export interface IFrameworkPluginNextInputs {
    * @default npm run build
    */
   buildCommand?: string;
+  /**
+   * 安装命令，如`npm install`，没有可不传
+   *
+   * @default npm run build
+   */
+  installCommand?: string;
 
   /**
    * 函数运行时版本
@@ -121,8 +128,8 @@ class NextPlugin extends Plugin {
       'package.json'
     );
     if (fs.existsSync(packageJsonPath)) {
-      this.api.logger.info('npm install');
-      return promisify(exec)('npm install', {
+      this.api.logger.info(`package install: ${this.resolvedInputs.installCommand}`);
+      return promisify(exec)(this.resolvedInputs.installCommand, {
         cwd: this.resolvedInputs.entry,
       });
     }


### PR DESCRIPTION
默认执行的 `package.json` 安装命令为 `npm install` 未考虑到使用 `yarn` `pnpm` 等用户。

Fixs #

Changes in this pull request

- `packages/framework-plugin-next/src/index.ts`

@binggg
